### PR TITLE
Switch JSConf EU to 2019

### DIFF
--- a/conferences/jsconf.yaml
+++ b/conferences/jsconf.yaml
@@ -10,7 +10,7 @@
 # JSConf EU
 - jsconfeu:
     name: JSConf EU
-    site: https://2018.jsconf.eu
+    site: https://2019.jsconf.eu
     logo: images/jsconf_eu.png
     status: onsale
 


### PR DESCRIPTION
The splash page was launched at the 2018 event.